### PR TITLE
FIX To issue ECM-611

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -101,14 +101,23 @@ export function put(url, body){
 
 function handleResponse(response, resolve, reject){
   observer.send('loading-sender', 'section-loading', {loading:false})
-  if (response.status === 200 || response.status === 201) {
-    response.text().then(data => {
-      if(data){
-        resolve(JSON.parse(data))
-      } else {
-        resolve()
-      }
-    });
+  if (response.status === 200 ||  response.status === 201) {
+
+    if(response.url && JSON.stringify(response.url).indexOf('/auth/faces/public/login.jsf')===1 ) {
+      observer.send('error-sender', 'error', 'Your session has timed out. Please <a href="/">login again</a>')
+      reject(null)
+    } else {
+      response.text().then(data => {
+        if(data){
+          resolve(JSON.parse(data))
+        } else {
+          resolve()
+        }
+      });
+
+    }
+
+
   } else {
      if(response.status === 302){
        // timeout


### PR DESCRIPTION
At the moment even if the security session is not available, the pages
can be accessed if it is still in the browser cache. The pages are
rendered using the cached js /html files. The failed rest service calls
are not properly at the moment. OAM detects that the rest service calls
are from an unauthenticated user and it attempts to redirect the AJAX
calls to '/auth/faces/private/login.jsf' page for the user to get
authenticated. These responses were nbot handled correct earlier. We
fixed it now.